### PR TITLE
Fix FPE at low temperatures relative to group bounds

### DIFF
--- a/MultiGroupIntegrator.cc
+++ b/MultiGroupIntegrator.cc
@@ -146,16 +146,51 @@ void MultiGroupIntegrator::computeGroupAverages(const double T,
          }
       }
 
-      planckAverage[g] = groupResults[0] / groupResults[1];
-      rosselandAverage[g] = groupResults[2] / groupResults[3];
+      if (groupResults[1] > 0.0)
+      {
+         planckAverage[g] = groupResults[0] / groupResults[1];
+      }
+      else
+      {
+         // For very large epsilon = groupBounds/T, the denominator is zero
+         // The weight is also a rapidly decaying exponetial, so the average
+         // will essentially be at the left boundary of the group.
+         planckAverage[g] = opac.computeKappa(groupBounds[g] / T, T, rho);
+      }
+
+      if (groupResults[3] > 0.0)
+      {
+         rosselandAverage[g] = groupResults[2] / groupResults[3];
+      }
+      else
+      {
+         // For very large epsilon = groupBounds/T, the denominator is zero
+         // The weight is also a rapidly decaying exponetial, so the average
+         // will essentially be at the left boundary of the group.
+         rosselandAverage[g] = opac.computeKappa(groupBounds[g] / T, T, rho);
+      }
 
       // We need unshifted values the for total emission calculation
       b_g[g] = groupResults[5];
       dbdT_g[g] = groupResults[6];
    }
    // Compute grey results.
-   planckMean = globalResults[0] / globalResults[1];
-   rosselandMean = globalResults[2] / globalResults[3];
+   if (globalResults[0] > 0.0 and globalResults[1] > 0.0)
+   {
+      planckMean = globalResults[0] / globalResults[1];
+   }
+   else
+   {
+      planckMean = 0.0;
+   }
+   if (globalResults[0] > 0.0 and globalResults[3] > 0.0)
+   {
+      rosselandMean = globalResults[2] / globalResults[3];
+   }
+   else
+   {
+      rosselandMean = 0.0;
+   }
 }
 
 //-----------------------------------------------------------------------------

--- a/opacTest.cc
+++ b/opacTest.cc
@@ -14,6 +14,10 @@
 #define FMT_HEADER_ONLY 1
 #include "fmt/format.h"
 
+#if defined(__linux__)
+#include <fenv.h>
+#endif
+
 void printRange(std::FILE *file, const std::vector<double> &xs, std::string name)
 {
    fmt::print(file, "{} = [", name);
@@ -36,6 +40,13 @@ void printRange(std::FILE *file, std::vector<double> &xs, std::string name, std:
 
 int main()
 {
+#if defined(__linux__)
+   // This is in here for supporting Linux's floating point exceptions.
+   feenableexcept(FE_DIVBYZERO);
+   feenableexcept(FE_INVALID);
+   feenableexcept(FE_OVERFLOW);
+#endif
+
    //-------------------------------------------------------------------
    // Open an output file for testing.
    std::FILE *planckFile = std::fopen("data.py", "w");
@@ -61,7 +72,7 @@ int main()
                            2.826076380281411e+01,
                            4.500000000000000e+01};
 
-   std::vector temps{1.0e-3, 1.0e-2, 0.1, 0.5, 1.0};
+   std::vector temps{1.0e-6, 1.0e-5, 1.0e-4, 1.0e-3, 1.0e-2, 0.1, 0.5, 1.0, 10.0, 100.0, 1000.0};
    std::vector materials{std::make_tuple(/*name =*/"iron",
                                          /*epsilonMin =*/0.05,
                                          /*epsilonEdge =*/7.0,


### PR DESCRIPTION
If the temperature is very small relative to the group bounds, there was a divide by zero error.  This change protects against that.